### PR TITLE
CI: Add limited installation of arduino platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.7"
 cache:
   directories:
-    - ~/arduino_ide
     - ~/.arduino15/packages/
 before_install:
   - export INSTALL_PLATFORMS="esp32"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ cache:
     - ~/arduino_ide
     - ~/.arduino15/packages/
 before_install:
-  - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
+  - export INSTALL_PLATFORMS="esp32"
+  - source <(curl -SLs https://raw.githubusercontent.com/andrewda/travis-ci-arduino/custom-install/install.sh)
   # Arduino IDE adds a lot of noise caused by network traffic, trying to firewall it off
   - sudo iptables -P INPUT DROP
   - sudo iptables -P FORWARD DROP


### PR DESCRIPTION
This limits the installation to just ESP32, cutting build time from ~7min to ~2min.